### PR TITLE
2021 11 03 group edit

### DIFF
--- a/spec/bow_specification/bow_specification.mdk
+++ b/spec/bow_specification/bow_specification.mdk
@@ -477,6 +477,7 @@ If implemented, DBI is in the Link Layer and must be implemented on both RX and 
 Figure [#fig-bow-logicin] shows the data and control signals in the interfaces to 
 the logic in the die in each BoW transmit and receive slice. The data at the slice 
 logic interface must be SDR (Single Data Rate - bit rate equal to the PCLK frequency). 
+
 <XX
 The BoW PHY is 
 expected to be used with a link controller. The transmission of logical information 
@@ -941,9 +942,12 @@ logic 0 and logic 1 voltages on the wire between the TX and RX.
 [S11]: images/s11_max.png {width:auto; max-width:80% }
 
 ~ framed {color: blue}
-Nov 2021: simulation with example channels show that we either need to reduce the capacitance to 200 fF
-(9.8 dB S11) or reduce the Rx eye opening to 30-40% UI to reach 1e-15 BER.
+**
+Nov 2021: simulation with example channels show that we either need to reduce the capacitance 
+from 300 to 200 fF
+(9.8 dB S11) or reduce the Rx eye opening from 50% UI to 30-40% to reach 1e-15 BER.
 This is unresolved.
+**
 ~
 
 ## Receiver Bandwidth
@@ -978,53 +982,6 @@ However, the bits at the RX PHY logic interface P_D[*] may be offset by a multip
 if the TX and RX PCLK dividers are not aligned.
 A PHY implementation may provide a way to align the TX and RX dividers, or it may rely on the Link Layer
 to rotate the RX P_D[*] bits to provide that alignment as part of the training of the Link Layer.
-
-
-<XX
-~framed {color: blue}
-Alternate description of the same ordering:
-
-On the "first" serial cycle, CLK+ rises (CLK- falls),  
-D[0] sends P_D[0],  
-D[1] sends P_D[1],  
-... ,  
-D[15] sends P_D[15]
-   
-   
-On the "second" serial cycle, CLK+ falls (CLK- rises),  
-D[0] sends P_D[16],  
-D[1] sends P_D[17],  
-.. ,  
-D[15] sends P_D[31]  
-...
-
-~
-.
-
-~ framed {color: blue}
-But Keysight implemented this:  
-1st cycle:  
-D[0] sends P_D[0]  
-D[1] sends P_D[8]  
-D[2] sends P_D[16]  
-...  
-D[15] sends P_D[120]  
-
-2nd cycle:  
-D[0] sends P_D[1]  
-D[1] sends P_D[9]  
-...
-
-8th cycle  
-D[0] sends P_D[7]  
-...  
-D[15] sends P_D[127]  
-
-Is there an industry-standard ordering for other serializers?  
-  
-Keysight's implementation relies on the Link Layer to align the P_D[*] bits.
-~
->
 
 
 ## Clocking
@@ -1416,52 +1373,6 @@ What is the origin of the Xtalk Limit equation?  Is there a paper reference?
 ~
 XX>
 
-# BoW in an ODSA Design
-Chiplet-based designs require logical connectivity between the die in a
-single package, in addition to physical connectivity. This section provides an overview of 
-how the Open Domain-Specific Architecture stack can be used as an underlay for 
-popular transaction protocols.
-
-## BoW for Common Transaction Protocols
-Two connected die in a multi-chiplet device need to exchange logical information. 
-The ODSA aims to define an open physical and logical interface for chiplets, as shown in 
-Figure [#fig-odsa-stack] to enable chiplets from multiple vendors to interoperate and be 
-integrated in a multi-die package. The Bunch of Wires is an open D2D PHY option in the
-interface. The logical component of the ODSA interface aims to 
-support protocols used for the two most common chiplet use cases, package 
-aggregation and die disaggregation across a wide range of open and proprietary D2D PHYs
-such as PCIe, CXL, CCIX, AXI and proprietary streaming protocols. 
-
-~ Figure {#fig-odsa-stack; caption: "The BoW PHY in the ODSA Stack"}
-![bowspec_figstack]
-~
-[bowspec_figstack]: images/bowspec_odsa_stack.jpg "bowspec_figure1" {width:auto; max-width:100%}
-
-The ODSA stack abstracts
-the PHY layer from the logical interface by using the well-defined abstraction interfaces
-PIPE and LPIF. 
-Any logic transaction controller, such as a PCIe controller, that
-supports a PIPE or LPIF interface can use any D2D PHY that also supports that
-interface as its physical layer.
-As shown in Figure [#fig-odsa-stack], the BoW interface may receive data
-through either the PIPE or LPIF interfaces to support common transaction protocols. 
-For this use case, some BoW-specific adapter logic will be needed to support the requirements of PIPE 
-or LPIF.
-The specifications for these adapters are outside the scope of this document. 
-Figure [#fig-bow-pcie] shows how the
-BoW with an PIPE adapter can be interfaced to a PCIe controller.
-
-~ Framed {color: blue}
-Bapi: please remove "serializer" and "deserializer" from the labels in Figure [#fig-bow-pcie]
- - these are part of the PHY.
-~
-
-
-
-~ Figure {#fig-bow-pcie; caption: "BoW with a PIPE adapter for PCIe transactions"}
-![bowspec_figcomponentspcie]
-~
-[bowspec_figcomponentspcie]: images/fig-bow_pcie.jpg {width:auto; max-width: 100%}
 
 
 # Reset and Initialization
@@ -1677,3 +1588,49 @@ to loop back the data from the transmitter of chiplet-A to the receiver of chipl
 
 
 
+# BoW in an ODSA Design
+Chiplet-based designs require logical connectivity between the die in a
+single package, in addition to physical connectivity. This section provides an overview of 
+how the Open Domain-Specific Architecture stack can be used as an underlay for 
+popular transaction protocols.
+
+## BoW for Common Transaction Protocols
+Two connected die in a multi-chiplet device need to exchange logical information. 
+The ODSA aims to define an open physical and logical interface for chiplets, as shown in 
+Figure [#fig-odsa-stack] to enable chiplets from multiple vendors to interoperate and be 
+integrated in a multi-die package. The Bunch of Wires is an open D2D PHY option in the
+interface. The logical component of the ODSA interface aims to 
+support protocols used for the two most common chiplet use cases, package 
+aggregation and die disaggregation across a wide range of open and proprietary D2D PHYs
+such as PCIe, CXL, CCIX, AXI and proprietary streaming protocols. 
+
+~ Figure {#fig-odsa-stack; caption: "The BoW PHY in the ODSA Stack"}
+![bowspec_figstack]
+~
+[bowspec_figstack]: images/bowspec_odsa_stack.jpg "bowspec_figure1" {width:auto; max-width:100%}
+
+The ODSA stack abstracts
+the PHY layer from the logical interface by using the well-defined abstraction interfaces
+PIPE and LPIF. 
+Any logic transaction controller, such as a PCIe controller, that
+supports a PIPE or LPIF interface can use any D2D PHY that also supports that
+interface as its physical layer.
+As shown in Figure [#fig-odsa-stack], the BoW interface may receive data
+through either the PIPE or LPIF interfaces to support common transaction protocols. 
+For this use case, some BoW-specific adapter logic will be needed to support the requirements of PIPE 
+or LPIF.
+The specifications for these adapters are outside the scope of this document. 
+Figure [#fig-bow-pcie] shows how the
+BoW with an PIPE adapter can be interfaced to a PCIe controller.
+
+~ Framed {color: blue}
+Need to remove "serializer" and "deserializer" from the labels in Figure [#fig-bow-pcie]
+ - these are part of the PHY, not the PIPE adaptor.j
+~
+
+
+
+~ Figure {#fig-bow-pcie; caption: "BoW with a PIPE adapter for PCIe transactions"}
+![bowspec_figcomponentspcie]
+~
+[bowspec_figcomponentspcie]: images/fig-bow_pcie.jpg {width:auto; max-width: 100%}

--- a/spec/bow_specification/bow_specification.mdk
+++ b/spec/bow_specification/bow_specification.mdk
@@ -940,6 +940,12 @@ logic 0 and logic 1 voltages on the wire between the TX and RX.
 ~
 [S11]: images/s11_max.png {width:auto; max-width:80% }
 
+~ framed {color: blue}
+Nov 2021: simulation with example channels show that we either need to reduce the capacitance to 200 fF
+(9.8 dB S11) or reduce the Rx eye opening to 30-40% UI to reach 1e-15 BER.
+This is unresolved.
+~
+
 ## Receiver Bandwidth
 
 While this specification does not place a direct requirement on the bandwidth of a BoW
@@ -958,7 +964,7 @@ is recommended to be at least 10.667 GHz.
 
 ## Bit Ordering
 
-~ framed {color: blue}
+
 The PHY TX serializer shall order data this way (referring to Figure [#fig-clocking]):  
 
 * On the first CLK edge (CLK+ rising) bits P_D[0:15] are sent on wires D[0:15]   
@@ -972,8 +978,9 @@ However, the bits at the RX PHY logic interface P_D[*] may be offset by a multip
 if the TX and RX PCLK dividers are not aligned.
 A PHY implementation may provide a way to align the TX and RX dividers, or it may rely on the Link Layer
 to rotate the RX P_D[*] bits to provide that alignment as part of the training of the Link Layer.
-~
-.
+
+
+<XX
 ~framed {color: blue}
 Alternate description of the same ordering:
 
@@ -1017,6 +1024,7 @@ Is there an industry-standard ordering for other serializers?
   
 Keysight's implementation relies on the Link Layer to align the P_D[*] bits.
 ~
+>
 
 
 ## Clocking
@@ -1412,7 +1420,7 @@ XX>
 # BoW in an ODSA Design
 Chiplet-based designs require logical connectivity between the die in a
 single package, in addition to physical connectivity. This section provides an overview of 
-how with the Open Domain-Specific Architecture stack it can be used as an underlay for 
+how the Open Domain-Specific Architecture stack can be used as an underlay for 
 popular transaction protocols.
 
 ## BoW for Common Transaction Protocols
@@ -1471,18 +1479,23 @@ or outside the package.
 This could be a serial link like SPI or I2C, but this is not specified at this time.
 * A source of training pattern data outside the PHY, assumed to be the Link Layer here.
 This must be able to repetitively
-transmit an arbitrary 288-bit pattern (16 bits per wire) required by the RX slice for clock 
+transmit an arbitrary 16 bit per wire pattern (256 or 288 bits pattern depending on inclusion of FEC+AUX) 
+required by the RX slice for clock
 alignment as specified in the datasheet for the RX PHY.
-* The Reset input to each PHY shall be asserted upon powerup. 
+* The PHYReset input to each PHY shall be asserted upon powerup. 
 It may also be asserted by commands from the LC.
 
 An example topology is shown in Figure [#fig-bow_system]. 
-The BoW interface communicates to interface and core logic blocks.
+The BoW interface communicates to interface and core logic (I&C) blocks.
 
 ~ Figure { #fig-bow_system; caption: "Example BoW System Configuration" }
 ![bow_system]
 ~
 [bow_system]: images/bow_system.png { width:auto; max-width:70% }
+
+~ framed {color:blue}
+Add another figure with the LC embedded rather than external
+~
 
 ## Initialization Sequence
 
@@ -1490,33 +1503,33 @@ A TX-RX Link shall be brought up as follows:
 
 1. The Link Controller (LC) performs any needed configuration of the PHY 
 slices via the APB interface. This is implementation dependent
-1. The LC de-asserts Reset to the TX PHY slices
-1. Once its TX clock stabilizes, each TX PHY slice asserts Ready to the LC
+1. The LC de-asserts PHYReset to the TX PHY slices
+1. Once its TX clock stabilizes, each TX PHY slice asserts PHYReady to the LC
 1. When all TX PHY slices are ready, the LC signals the TX Link Layer to 
-send the clock training pattern (repeating indefinitely) specified by the RX PHY
-1. The LC de-asserts Reset to the RX PHY slices 
-1. Each RX PHY slice performs clock and data alignment and signals Ready to the LC when done
+send the training pattern (repeating indefinitely) specified by the RX PHY
+1. The LC de-asserts PHYReset to the RX PHY slices 
+1. Each RX PHY slice performs clock and data alignment and signals PHYReady to the LC when done
 1. When all RX PHY slices are ready, the LC signals the TX and RX 
 Link Layers that they can proceed with channel bonding
 
-Not specified:
+Implementation dependent:
 
 * Whether the up and down links are initialized one at a time or in parallel
-* How the signals from the the LC get from the I2C to the PHY Ready and Reset pins of the PHY
+* How the signals from the the LC get from and to the PHYReady and PHYReset pins of the PHY
 * How the Link Layer performs channel bonding or start of data transmission
 * Any PHY registers required to implement this process - these
 are an implementation choice. 
 
 
-## Other Unspecified Areas
+## Unspecified Items
 
 * There is no low-power standby mode defined.
-* There is no specification for when a PHY should de-assert its Ready pin. 
+* There is no specification for when a PHY should de-assert its PHYReady pin. 
 PLL or DLL losing lock are possible causes.
-* There is no definition of what occurs if the PHY does de-assert Ready
+* There is no definition of what occurs if the PHY does de-assert PHYReady
 * There is no definition of what should be done with unused PHYs 
 (that are on the chip but have no partner on another chiplet)
-* There is no definition of addressing chiplets, Links or slices
+* There is no definition of logical addressing of chiplets, Links or slices
 * Possible use of PRBS patterns for training
 
 
@@ -1555,7 +1568,7 @@ The registers shall be fully documented in the PHY datasheet.
 How do other specs do this?
 ~
 
-Test patterns should be programmable to repeat indefiniately.
+Test patterns should be programmable to repeat indefinitely.
 
 Suggested test patterns are:
 
@@ -1584,19 +1597,19 @@ A BoW interface may implement loopback testing for several use cases:
 at chiplet wafer-sort test, post-assembly package test, and debug/validation. 
 
 Wafer sort tests are currently only practical for the BoW interface with 
-regular bump pitches (~130um), where ATE (automatic testing equipment) probe 
+regular bump pitches (~130 &mu;m), where ATE (automatic testing equipment) probe 
 boards with matching pin pitches are available. 
 Microbump probes will require additional effort.
 
-Unidirectional links need open-loop testing. 
+Unidirectional links should support open-loop testing. 
 In TX open loop testing, shown in Figure [#fig_test_tx], Chiplet-A transmits a 
 known test pattern (PRBS9 or PRBS31) to a golden reference receiver through the ATE load board. 
-The received pattern is verified in the ATE load board.
+The received pattern should be verified in the ATE load board.
 
 RX open loop testing, shown in Figure [#fig_test_rx], is used for a link 
 where the DUT is only a receiver. 
 A golden reference TX transmits a known pattern (PRBS9 or PRBS31) through the channel to the chiplet. 
-The received pattern will be analyzed for quality and functional tests. 
+The received pattern should be analyzed for quality and functional tests. 
 
 The logic for generating and testing the PRBS sequences is outside the PHY, e.g., in the Link Layer.
 
@@ -1613,23 +1626,23 @@ The logic for generating and testing the PRBS sequences is outside the PHY, e.g.
 
 In bidirectional links, loopback tests can be implemented in several modes:
 
- * slice-to-slice short loopback 
+ * Slice-to-slice short loopback 
   * Data is looped back within the chip
  from a TX slice to an RX slice using on-chip switching (shown in Figure [#fig_test_sl]). 
  The short loopback path is configured by the ATE using implementation-dependent registers.
   * Loopback can be implemented before the PHY serializer, between the serializer and the output buffer, 
   and/or at the bumps. 
- * intra-slice short loopback
+ * Intra-slice short loopback
   * A single slice containing both RX and TX paths sharing the same bumps
  can perform on-chip loopback testing simply by turning on both the RX and TX paths at once.
  This has more on-chip circuitry, but allows loopback testing with no switches or extra 
  lines connected to the bumps other than the TX driver tristate switches. 
  Figure [#fig_test_sl] applies, except there is only one shared set of bumps for a TX/RX slice.
- * long loopback 
-  * the PRBS pattern is generated by chiplet-A, sent over the replica channel on the ATE 
+ * Long loopback 
+  * The PRBS pattern is generated by chiplet-A, sent over the replica channel on the ATE 
   load board which loops it back 
  (shown in Figure [#fig_test_ll]). 
- The received pattern will be passed to a bit error rate tester (BERT) to analyze the 
+ The received pattern should be passed to a bit error rate tester (BERT) to analyze the 
  performance of the link with off-chip data and clock wires.
 
 

--- a/spec/bow_specification/bow_specification.mdk
+++ b/spec/bow_specification/bow_specification.mdk
@@ -1120,15 +1120,14 @@ the TxClk distribution on Chiplet A probably dominates the
 the clock skew of the TX slices on Chiplet A and the clock skew of the RX slices on Chiplet B,
 and vice versa for flow from B to A. 
 The skew between Tx CLK signals within one direction of a link 
-must be no more than 150 ps/stack along the chip edge.
+should be no more than 150 ps/stack along the chip edge.
 There is no specification of the skew between TxClk on Chiplet A vs. TxClk on Chiplet B nor between
 different links.
 
-~ Framed {color: blue}
-TBD: does PCLK need to be aligned to 150 ps/stack?  Do we reset PCLK dividers?
-
-Keysight does not align PCLK dividers and makes the Link Layer CDC handle this.
-~
+Note that the dividers creating PCLK in each PHY slice are not required to be aligned.
+This implies that they will tend to have random starting states,
+leading to additional PCLK misalignment between slices of up to one PCLK period.
+PHY implementations may optionally include methods to align these dividers.
 
 On both the TX and RX sides, the Link Layer will usually need to include a Clock Domain Crossing (CDC) to 
 align the data between CoreClk and PCLK. 
@@ -1284,7 +1283,7 @@ Overshoot depends on Tx and Channel. Overshoot spec protects the Rx from damage.
 ### Slice-to-Clice CLK Skew
 
 The slice to slice clock skew t~skew~ across the width of a BoW link (along the chip edge) 
-must be less than **150 ps/stack**. 
+should be less than 150 ps/stack. 
 (E.g., for a 4-stack interface, the skew from end to end must be less than 600 ps.)
 This skew includes only analog delays and specifically does not include any 
 clock-related timing skew due to 

--- a/spec/bow_specification/ignores.dic
+++ b/spec/bow_specification/ignores.dic
@@ -15,3 +15,4 @@ datasheet
 loopback
 chiplet
 Microbump
+PCLK


### PR DESCRIPTION
Additional edits from the 24 Nov 2021 group edit: moving the section BoW in ODSA and cleaning up the bit serialization ordering text
